### PR TITLE
fix macOS build

### DIFF
--- a/dragonnet/sock.h
+++ b/dragonnet/sock.h
@@ -15,4 +15,7 @@
 #include <netinet/in.h>
 #include <arpa/inet.h>
 #include <netdb.h>
+#ifndef MSG_MORE
+#define MSG_MORE 0
+#endif
 #endif


### PR DESCRIPTION
Fixes https://github.com/dragonblocks/dragonnet/issues/5

Makes macOS builds succeed by providing a `MSG_MORE` fallback in `sock.h` for platforms that don’t define it. Keeps behavior unchanged on platforms that support the flag.